### PR TITLE
fix dos hole

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1714,7 +1714,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck)
         }
 
         if (vtx[0].GetValueOut() > GetProofOfWorkReward(pindex->nHeight, prevHash))
-                return false;
+       return DoS(100, error("ConnectBlock() : coinbase pays too much (actual=%"PRI64d" vs limit=%"PRI64d")", vtx[0].GetValueOut(), GetBlockValue(pindex->nHeight, nFees)));
 
     // Update block index on disk without changing it in memory.
     // The memory index structure will be changed after the db commits.


### PR DESCRIPTION
-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA1

LottoTickets

I fixed dos hole

possible unlimited coin but can not confirm.

please discuss
-----BEGIN PGP SIGNATURE-----
Version: BCPG v1.47

iHwEARECADwFAlLgOek1HEFzaCBLZXRjaHVtIChBc2ggS2V0Y2h1bSkgPGFzaGtl
dGNodW1AdmlzdG9tYWlsLmNvbT4ACgkQu8Tc5rjr4IllwwCg71KUfltxhxuGUORG
Q4g+RduiU3AAnigTEAX1k7k500JXvhEAVx4aYewp
=LY6O
-----END PGP SIGNATURE-----
